### PR TITLE
Right click option to override default delimiter

### DIFF
--- a/src/main/java/com/andrey4623/rainbowcsv/CsvFile.java
+++ b/src/main/java/com/andrey4623/rainbowcsv/CsvFile.java
@@ -3,10 +3,9 @@ package com.andrey4623.rainbowcsv;
 import com.intellij.extapi.psi.PsiFileBase;
 import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.psi.FileViewProvider;
-
-import javax.swing.Icon;
-
 import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
 
 public class CsvFile extends PsiFileBase {
 

--- a/src/main/java/com/andrey4623/rainbowcsv/CsvTokenParser.java
+++ b/src/main/java/com/andrey4623/rainbowcsv/CsvTokenParser.java
@@ -8,10 +8,12 @@ import java.util.List;
 import java.util.Objects;
 
 public class CsvTokenParser {
+    private static CsvSettings csvSettings;
 
-    public static List<List<TextRange>> parseCsv(String text) {
+    public static List<List<TextRange>> parseCsv(CsvSettings parsingSettings, String text) {
         List<List<TextRange>> result = new ArrayList<>();
 
+        csvSettings = parsingSettings;
         final char delimiter = getDelimiter();
         final char escapeCharacter = getEscapeCharacter();
         final boolean highlightComments = isHighlightComments();
@@ -117,19 +119,19 @@ public class CsvTokenParser {
     }
 
     private static char getDelimiter() {
-        return CsvSettings.getInstance().getDelimiter().getDelimiter();
+        return csvSettings.getDelimiter().getDelimiter();
     }
 
     private static char getEscapeCharacter() {
-        return CsvSettings.getInstance().getEscapeCharacter().getEscapeCharacter();
+        return csvSettings.getEscapeCharacter().getEscapeCharacter();
     }
 
     private static boolean isHighlightComments() {
-        return CsvSettings.getInstance().isHighlightComments();
+        return csvSettings.isHighlightComments();
     }
 
     private static String getCommentPrefix() {
-        return CsvSettings.getInstance().getCommentPrefix();
+        return csvSettings.getCommentPrefix();
     }
 
     public static class TextRange {

--- a/src/main/java/com/andrey4623/rainbowcsv/RainbowHighlightVisitor.java
+++ b/src/main/java/com/andrey4623/rainbowcsv/RainbowHighlightVisitor.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.editor.markup.TextAttributes;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
+import com.intellij.util.xmlb.XmlSerializerUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
@@ -17,28 +18,48 @@ import java.util.List;
 public class RainbowHighlightVisitor implements HighlightVisitor {
 
     private HighlightInfoHolder holder;
-
     private TextAttributes[] columnTextAttributes = new TextAttributes[0];
     private TextAttributes commentLineTextAttributes;
 
+    private static boolean isEnabled() {
+        return CsvSettings.getInstance().isEnabled();
+    }
+
+    private static TextRange convertTextRange(CsvTokenParser.TextRange textRange) {
+        return new TextRange(textRange.getStartOffset(), textRange.getEndOffset());
+    }
+
     @Override
     public boolean suitableForFile(@NotNull PsiFile file) {
-        return CsvFileType.INSTANCE.equals(file.getFileType());
+        return (CsvFileType.INSTANCE.equals(file.getFileType()))
+                || (file.getVirtualFile().getUserData(CsvSettings.CSV_SETTINGS_DATA_KEY) != null);
     }
 
     @Override
     public void visit(@NotNull PsiElement element) {
-        if (!(element instanceof CsvFile)) {
+        if (!(element instanceof PsiFile)) {
             return;
         }
 
-        if (!isEnabled()) {
+        CsvSettings fileCsvSettings = ((PsiFile) element).getVirtualFile().getUserData(CsvSettings.CSV_SETTINGS_DATA_KEY);
+        if (fileCsvSettings == null) {
+            if (element instanceof CsvFile) {
+                // Use default settings if file settings undefined.
+                fileCsvSettings = XmlSerializerUtil.createCopy(CsvSettings.getInstance());
+                ((CsvFile) element).getVirtualFile().putUserData(CsvSettings.CSV_SETTINGS_DATA_KEY, fileCsvSettings);
+            } else {
+                return;
+            }
+        }
+
+        if (!isEnabled() || !fileCsvSettings.isEnabled()) {
             return;
         }
+
 
         final String csvFileContent = element.getText();
         if (csvFileContent != null) {
-            List<List<CsvTokenParser.TextRange>> lines = CsvTokenParser.parseCsv(csvFileContent);
+            List<List<CsvTokenParser.TextRange>> lines = CsvTokenParser.parseCsv(fileCsvSettings, csvFileContent);
             for (List<CsvTokenParser.TextRange> line : lines) {
                 for (int i = 0; i < line.size(); i++) {
                     final CsvTokenParser.TextRange textRange = line.get(i);
@@ -62,14 +83,6 @@ public class RainbowHighlightVisitor implements HighlightVisitor {
                 }
             }
         }
-    }
-
-    private static boolean isEnabled() {
-        return CsvSettings.getInstance().isEnabled();
-    }
-
-    private static TextRange convertTextRange(CsvTokenParser.TextRange textRange) {
-        return new TextRange(textRange.getStartOffset(), textRange.getEndOffset());
     }
 
     @Override

--- a/src/main/java/com/andrey4623/rainbowcsv/action/CsvSettingsModifier.java
+++ b/src/main/java/com/andrey4623/rainbowcsv/action/CsvSettingsModifier.java
@@ -1,0 +1,22 @@
+package com.andrey4623.rainbowcsv.action;
+
+import com.andrey4623.rainbowcsv.settings.CsvSettings;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.FileContentUtilCore;
+import com.intellij.util.xmlb.XmlSerializerUtil;
+
+import java.util.function.Consumer;
+
+public interface CsvSettingsModifier {
+
+    default void modifySettingsAndReparse(VirtualFile currentFile, Consumer<CsvSettings> settingsConsumer) {
+        CsvSettings fileSettings = currentFile.getUserData(CsvSettings.CSV_SETTINGS_DATA_KEY);
+        if (fileSettings == null) {
+            fileSettings = XmlSerializerUtil.createCopy(CsvSettings.getInstance());
+        }
+        settingsConsumer.accept(fileSettings);
+        currentFile.putUserData(CsvSettings.CSV_SETTINGS_DATA_KEY, fileSettings);
+
+        FileContentUtilCore.reparseFiles(currentFile);
+    }
+}

--- a/src/main/java/com/andrey4623/rainbowcsv/action/RainbowfyByColon.java
+++ b/src/main/java/com/andrey4623/rainbowcsv/action/RainbowfyByColon.java
@@ -1,0 +1,21 @@
+package com.andrey4623.rainbowcsv.action;
+
+import com.andrey4623.rainbowcsv.Delimiter;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.PlatformDataKeys;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+
+public class RainbowfyByColon extends AnAction implements CsvSettingsModifier {
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        VirtualFile currentFile = e.getData(PlatformDataKeys.VIRTUAL_FILE);
+
+        modifySettingsAndReparse(currentFile, fileCsvSettings -> {
+            fileCsvSettings.setEnabled(true);
+            fileCsvSettings.setDelimiter(Delimiter.COLON);
+        });
+    }
+}

--- a/src/main/java/com/andrey4623/rainbowcsv/action/RainbowfyByComma.java
+++ b/src/main/java/com/andrey4623/rainbowcsv/action/RainbowfyByComma.java
@@ -1,0 +1,20 @@
+package com.andrey4623.rainbowcsv.action;
+
+import com.andrey4623.rainbowcsv.Delimiter;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.PlatformDataKeys;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+
+public class RainbowfyByComma extends AnAction implements CsvSettingsModifier {
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        VirtualFile currentFile = e.getData(PlatformDataKeys.VIRTUAL_FILE);
+        modifySettingsAndReparse(currentFile, fileCsvSettings -> {
+            fileCsvSettings.setEnabled(true);
+            fileCsvSettings.setDelimiter(Delimiter.COMMA);
+        });
+    }
+}

--- a/src/main/java/com/andrey4623/rainbowcsv/action/RainbowfyByPipe.java
+++ b/src/main/java/com/andrey4623/rainbowcsv/action/RainbowfyByPipe.java
@@ -1,0 +1,20 @@
+package com.andrey4623.rainbowcsv.action;
+
+import com.andrey4623.rainbowcsv.Delimiter;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.PlatformDataKeys;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+
+public class RainbowfyByPipe extends AnAction implements CsvSettingsModifier {
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        VirtualFile currentFile = e.getData(PlatformDataKeys.VIRTUAL_FILE);
+        modifySettingsAndReparse(currentFile, fileCsvSettings -> {
+            fileCsvSettings.setEnabled(true);
+            fileCsvSettings.setDelimiter(Delimiter.PIPE);
+        });
+    }
+}

--- a/src/main/java/com/andrey4623/rainbowcsv/action/RainbowfyBySemicolon.java
+++ b/src/main/java/com/andrey4623/rainbowcsv/action/RainbowfyBySemicolon.java
@@ -1,0 +1,20 @@
+package com.andrey4623.rainbowcsv.action;
+
+import com.andrey4623.rainbowcsv.Delimiter;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.PlatformDataKeys;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+
+public class RainbowfyBySemicolon extends AnAction implements CsvSettingsModifier {
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        VirtualFile currentFile = e.getData(PlatformDataKeys.VIRTUAL_FILE);
+        modifySettingsAndReparse(currentFile, fileCsvSettings -> {
+            fileCsvSettings.setEnabled(true);
+            fileCsvSettings.setDelimiter(Delimiter.SEMICOLON);
+        });
+    }
+}

--- a/src/main/java/com/andrey4623/rainbowcsv/action/RainbowfyByTab.java
+++ b/src/main/java/com/andrey4623/rainbowcsv/action/RainbowfyByTab.java
@@ -1,0 +1,20 @@
+package com.andrey4623.rainbowcsv.action;
+
+import com.andrey4623.rainbowcsv.Delimiter;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.PlatformDataKeys;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+
+public class RainbowfyByTab extends AnAction implements CsvSettingsModifier {
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        VirtualFile currentFile = e.getData(PlatformDataKeys.VIRTUAL_FILE);
+        modifySettingsAndReparse(currentFile, fileCsvSettings -> {
+            fileCsvSettings.setEnabled(true);
+            fileCsvSettings.setDelimiter(Delimiter.TAB);
+        });
+    }
+}

--- a/src/main/java/com/andrey4623/rainbowcsv/action/RainbowfyToggle.java
+++ b/src/main/java/com/andrey4623/rainbowcsv/action/RainbowfyToggle.java
@@ -1,0 +1,18 @@
+package com.andrey4623.rainbowcsv.action;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.PlatformDataKeys;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+
+public class RainbowfyToggle extends AnAction implements CsvSettingsModifier {
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        VirtualFile currentFile = e.getData(PlatformDataKeys.VIRTUAL_FILE);
+        modifySettingsAndReparse(currentFile, fileCsvSettings ->
+                fileCsvSettings.setEnabled(!fileCsvSettings.isEnabled()));
+
+    }
+}

--- a/src/main/java/com/andrey4623/rainbowcsv/settings/CsvSettings.java
+++ b/src/main/java/com/andrey4623/rainbowcsv/settings/CsvSettings.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
+import com.intellij.openapi.util.Key;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -15,20 +16,9 @@ import org.jetbrains.annotations.Nullable;
 )
 public class CsvSettings implements PersistentStateComponent<CsvSettingsData> {
 
-    private CsvSettingsData csvSettings = new CsvSettingsData();
-
+    public static final Key<CsvSettings> CSV_SETTINGS_DATA_KEY = new Key<>("File CSV Settings");
     private static final CsvSettings csvSettingsComponent = new CsvSettings();
-
-    @Nullable
-    @Override
-    public CsvSettingsData getState() {
-        return csvSettings;
-    }
-
-    @Override
-    public void loadState(@NotNull CsvSettingsData state) {
-        this.csvSettings = state;
-    }
+    private CsvSettingsData csvSettings = new CsvSettingsData();
 
     public CsvSettings() {
     }
@@ -46,51 +36,62 @@ public class CsvSettings implements PersistentStateComponent<CsvSettingsData> {
         return service;
     }
 
-    public void setEnabled(boolean enabled) {
-        getState().enabled = enabled;
+    @Nullable
+    @Override
+    public CsvSettingsData getState() {
+        return csvSettings;
+    }
+
+    @Override
+    public void loadState(@NotNull CsvSettingsData state) {
+        this.csvSettings = state;
     }
 
     public boolean isEnabled() {
         return getState().enabled;
     }
 
-    public void setWelcomeNotifyShowed(boolean welcomeNotifyShowed) {
-        getState().welcomeNotifyShowed = welcomeNotifyShowed;
+    public void setEnabled(boolean enabled) {
+        getState().enabled = enabled;
     }
 
     public boolean isWelcomeNotifyShowed() {
         return getState().welcomeNotifyShowed;
     }
 
-    public void setDelimiter(Delimiter delimiter) {
-        getState().delimiter = delimiter;
+    public void setWelcomeNotifyShowed(boolean welcomeNotifyShowed) {
+        getState().welcomeNotifyShowed = welcomeNotifyShowed;
     }
 
     public Delimiter getDelimiter() {
         return getState().delimiter;
     }
 
-    public void setEscapeCharacter(EscapeCharacter escapeCharacter) {
-        getState().escapeCharacter = escapeCharacter;
+    public void setDelimiter(Delimiter delimiter) {
+        getState().delimiter = delimiter;
     }
 
     public EscapeCharacter getEscapeCharacter() {
         return getState().escapeCharacter;
     }
 
-    public void setHighlightComments(boolean enabled) {
-        getState().highlightComments = enabled;
+    public void setEscapeCharacter(EscapeCharacter escapeCharacter) {
+        getState().escapeCharacter = escapeCharacter;
     }
 
     public boolean isHighlightComments() {
         return getState().highlightComments;
     }
 
-    public void setCommentPrefix(String commentPrefix) {
-        getState().commentPrefix = commentPrefix;
+    public void setHighlightComments(boolean enabled) {
+        getState().highlightComments = enabled;
     }
 
     public String getCommentPrefix() {
         return getState().commentPrefix;
+    }
+
+    public void setCommentPrefix(String commentPrefix) {
+        getState().commentPrefix = commentPrefix;
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,10 +1,10 @@
 <idea-plugin require-restart="true">
-  <id>com.andrey4623.rainbowcsv</id>
-  <name>Rainbow CSV</name>
-  <version>2.0.2</version>
-  <vendor email="andreyka4623@gmail.com" url="https://github.com/andrey4623">Andrey Kolchanov</vendor>
+    <id>com.andrey4623.rainbowcsv</id>
+    <name>Rainbow CSV</name>
+    <version>2.0.2</version>
+    <vendor email="andreyka4623@gmail.com" url="https://github.com/andrey4623">Andrey Kolchanov</vendor>
 
-  <description><![CDATA[
+    <description><![CDATA[
       Plugin for highlighting CSV files in different colors.
       <br /><br />
       <img width="600" src="https://raw.githubusercontent.com/andrey4623/intellij-rainbow-csv/master/screenshots/rainbow_csv.png" />
@@ -22,7 +22,7 @@
       Column colors can be changed in Preferences -> Editor -> Color Scheme -> Rainbow CSV.
     ]]></description>
 
-  <change-notes><![CDATA[
+    <change-notes><![CDATA[
     <p>2.0.2: 2022.1 Intellij support.</p>
     <p>2.0.1: Small improvements.</p>
     <p>2.0: Supports custom column colors and a custom comment line prefix.</p>
@@ -33,37 +33,65 @@
     <p>1.1: Bug fixes.</p>
     <p>1.0: This is the initial release of the plugin.</p>
     ]]>
-  </change-notes>
+    </change-notes>
 
-  <idea-version since-build="221.0"/>
+    <idea-version since-build="221.0"/>
 
-  <depends>com.intellij.modules.lang</depends>
+    <depends>com.intellij.modules.lang</depends>
 
-  <extensions defaultExtensionNs="com.intellij">
-    <highlightVisitor implementation="com.andrey4623.rainbowcsv.RainbowHighlightVisitor" />
+    <extensions defaultExtensionNs="com.intellij">
+        <highlightVisitor implementation="com.andrey4623.rainbowcsv.RainbowHighlightVisitor"/>
 
-    <lang.parserDefinition language="CSV" implementationClass="com.andrey4623.rainbowcsv.CsvParserDefinition"/>
+        <lang.parserDefinition language="CSV" implementationClass="com.andrey4623.rainbowcsv.CsvParserDefinition"/>
 
-    <fileType name="CSV file" implementationClass="com.andrey4623.rainbowcsv.CsvFileType" fieldName="INSTANCE"
-              language="CSV" extensions="csv" />
+        <fileType name="CSV file" implementationClass="com.andrey4623.rainbowcsv.CsvFileType" fieldName="INSTANCE"
+                  language="CSV" extensions="csv"/>
 
-    <fileTypeOverrider implementation="com.andrey4623.rainbowcsv.CsvFileTypeOverrider" />
+        <fileTypeOverrider implementation="com.andrey4623.rainbowcsv.CsvFileTypeOverrider"/>
 
-    <editorOptionsProvider instance="com.andrey4623.rainbowcsv.settings.Settings" />
+        <editorOptionsProvider instance="com.andrey4623.rainbowcsv.settings.Settings"/>
 
-    <colorAndFontPanelFactory implementation="com.andrey4623.rainbowcsv.settings.RainbowCsvColorAndFontPanelFactory" />
+        <colorAndFontPanelFactory
+                implementation="com.andrey4623.rainbowcsv.settings.RainbowCsvColorAndFontPanelFactory"/>
 
-    <colorAndFontDescriptorProvider implementation="com.andrey4623.rainbowcsv.RainbowColorAndFontDescriptorsProvider" />
+        <colorAndFontDescriptorProvider
+                implementation="com.andrey4623.rainbowcsv.RainbowColorAndFontDescriptorsProvider"/>
 
-    <applicationService serviceImplementation="com.andrey4623.rainbowcsv.settings.CsvSettings" />
+        <applicationService serviceImplementation="com.andrey4623.rainbowcsv.settings.CsvSettings"/>
 
-    <postStartupActivity implementation="com.andrey4623.rainbowcsv.startupactivity.WelcomeActivity" />
+        <postStartupActivity implementation="com.andrey4623.rainbowcsv.startupactivity.WelcomeActivity"/>
 
-    <additionalTextAttributes scheme="Default" file="colorSchemes/rainbow-csv-color-default.xml" />
+        <additionalTextAttributes scheme="Default" file="colorSchemes/rainbow-csv-color-default.xml"/>
 
-    <additionalTextAttributes scheme="Darcula" file="colorSchemes/rainbow-csv-color-default-darcula.xml" />
+        <additionalTextAttributes scheme="Darcula" file="colorSchemes/rainbow-csv-color-default-darcula.xml"/>
 
-    <notificationGroup id="RainbowCSV" displayType="STICKY_BALLOON" isLogByDefault="true"/>
-  </extensions>
+        <notificationGroup id="RainbowCSV" displayType="STICKY_BALLOON" isLogByDefault="true"/>
+    </extensions>
+
+    <actions>
+        <group id="RainbowCsvGroup" text="Rainbow CSV" description="Rainbow CSV" popup="true">
+            <add-to-group group-id="EditorTabPopupMenu"/>
+            <add-to-group group-id="EditorPopupMenu"/>
+            <action id="RainbowfyByComma"
+                    class="com.andrey4623.rainbowcsv.action.RainbowfyByComma"
+                    text="By Comma"/>
+            <action id="RainbowfyBySemicolon"
+                    class="com.andrey4623.rainbowcsv.action.RainbowfyBySemicolon"
+                    text="By Semicolon"/>
+            <action id="RainbowfyByPipe"
+                    class="com.andrey4623.rainbowcsv.action.RainbowfyByPipe"
+                    text="By Pipe"/>
+            <action id="RainbowfyByTab"
+                    class="com.andrey4623.rainbowcsv.action.RainbowfyByTab"
+                    text="By Tab"/>
+            <action id="RainbowfyByColon"
+                    class="com.andrey4623.rainbowcsv.action.RainbowfyByColon"
+                    text="By Colon"/>
+
+            <action id="RainbowfyToggle"
+                    class="com.andrey4623.rainbowcsv.action.RainbowfyToggle"
+                    text="Toggle"/>
+        </group>
+    </actions>
 
 </idea-plugin>

--- a/src/test/java/com/andrey4623/rainbowcsv/CsvTokenParserTest.java
+++ b/src/test/java/com/andrey4623/rainbowcsv/CsvTokenParserTest.java
@@ -1,5 +1,6 @@
 package com.andrey4623.rainbowcsv;
 
+import com.andrey4623.rainbowcsv.settings.CsvSettings;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -12,7 +13,7 @@ class CsvTokenParserTest {
 
     @Test
     void testEmptyString() {
-        assertEquals(Collections.emptyList(), CsvTokenParser.parseCsv(""));
+        assertEquals(Collections.emptyList(), CsvTokenParser.parseCsv(CsvSettings.getInstance(), ""));
     }
 
     @Test
@@ -40,7 +41,7 @@ class CsvTokenParserTest {
                 )
         );
 
-        List<List<CsvTokenParser.TextRange>> actual = CsvTokenParser.parseCsv("  ,, , abc , \"def\" , \"a\n" +
+        List<List<CsvTokenParser.TextRange>> actual = CsvTokenParser.parseCsv(CsvSettings.getInstance(), "  ,, , abc , \"def\" , \"a\n" +
                 "\n" +
                 "b\n" +
                 "\n" +


### PR DESCRIPTION
Added virtual file level settings separate from the defaults defined in Settings. Added actions to the editor and tab to change the delimiter for that file.