### PR TITLE
#19 - add configurable limit to length of lines in a file that will be rendered

### DIFF
--- a/src/main/java/com/andrey4623/rainbowcsv/RainbowHighlightVisitor.java
+++ b/src/main/java/com/andrey4623/rainbowcsv/RainbowHighlightVisitor.java
@@ -1,6 +1,7 @@
 package com.andrey4623.rainbowcsv;
 
 import com.andrey4623.rainbowcsv.settings.CsvSettings;
+import com.andrey4623.rainbowcsv.settings.CsvSettingsData;
 import com.intellij.codeInsight.daemon.impl.HighlightInfo;
 import com.intellij.codeInsight.daemon.impl.HighlightInfoType;
 import com.intellij.codeInsight.daemon.impl.HighlightVisitor;
@@ -33,6 +34,11 @@ public class RainbowHighlightVisitor implements HighlightVisitor {
         }
 
         if (!isEnabled()) {
+            return;
+        }
+
+        if (CsvSettings.getInstance().getMaxLinesToRender() <
+                ((CsvFile) element).getViewProvider().getDocument().getLineCount()) {
             return;
         }
 

--- a/src/main/java/com/andrey4623/rainbowcsv/settings/CsvSettings.java
+++ b/src/main/java/com/andrey4623/rainbowcsv/settings/CsvSettings.java
@@ -93,4 +93,12 @@ public class CsvSettings implements PersistentStateComponent<CsvSettingsData> {
     public String getCommentPrefix() {
         return getState().commentPrefix;
     }
+
+    public Integer getMaxLinesToRender() {
+        return getState().maxPageLines;
+    }
+
+    public void setMaxLinesToRender(int maxPageLines) {
+        getState().maxPageLines = maxPageLines;
+    }
 }

--- a/src/main/java/com/andrey4623/rainbowcsv/settings/CsvSettingsData.java
+++ b/src/main/java/com/andrey4623/rainbowcsv/settings/CsvSettingsData.java
@@ -19,6 +19,7 @@ public class CsvSettingsData {
     public boolean highlightComments = false;
 
     public String commentPrefix = "";
+    public int maxPageLines = 1000;
 
     public CsvSettingsData() {
     }

--- a/src/main/java/com/andrey4623/rainbowcsv/settings/Settings.form
+++ b/src/main/java/com/andrey4623/rainbowcsv/settings/Settings.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.andrey4623.rainbowcsv.settings.Settings">
-  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="6" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="7" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -13,7 +13,7 @@
       <grid id="f970" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -65,13 +65,13 @@
       </grid>
       <vspacer id="ca024">
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <grid id="5e297" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -100,7 +100,7 @@
       <grid id="7e7bd" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -124,7 +124,7 @@
       <grid id="6069d" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -152,6 +152,41 @@
               <text value=""/>
             </properties>
           </component>
+        </children>
+      </grid>
+      <grid id="a268d" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="5d957" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <labelFor value="2929e"/>
+              <text value="Only render files with less lines than:"/>
+            </properties>
+          </component>
+          <component id="2929e" class="javax.swing.JTextField" binding="pageLinesInput">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="150" height="-1"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value=""/>
+              <toolTipText value="Integers only"/>
+            </properties>
+          </component>
+          <hspacer id="b8c68">
+            <constraints>
+              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
         </children>
       </grid>
     </children>

--- a/src/main/java/com/andrey4623/rainbowcsv/settings/Settings.java
+++ b/src/main/java/com/andrey4623/rainbowcsv/settings/Settings.java
@@ -36,6 +36,8 @@ public class Settings implements EditorOptionsProvider {
     private JTextField commentPrefixTextField;
     private JCheckBox highlightCommentsCheckBox;
 
+    private JTextField pageLinesInput;
+
     @Override
     public @NotNull String getId() {
         return "RainbowCSV.Settings";
@@ -56,6 +58,7 @@ public class Settings implements EditorOptionsProvider {
         CsvSettings settings = CsvSettings.getInstance();
 
         return this.rainbowCSVEnabledCheckBox.isSelected() != settings.isEnabled()
+                || !settings.getMaxLinesToRender().equals(pageLinesInput.getText())
                 || !settings.getDelimiter().equals(this.delimiterComboBox.getSelectedItem())
                 || !settings.getEscapeCharacter().equals(this.escapeCharacterComboBox.getSelectedItem())
                 || settings.isHighlightComments() != this.highlightCommentsCheckBox.isSelected()
@@ -64,8 +67,17 @@ public class Settings implements EditorOptionsProvider {
 
     @Override
     public void apply() throws ConfigurationException {
+
+        try {
+            Integer.parseInt(pageLinesInput.getText());
+        }
+        catch (NumberFormatException exception) {
+            throw new ConfigurationException("Maximum lines must be an integer");
+        }
+
         CsvSettings settings = CsvSettings.getInstance();
         settings.setEnabled(rainbowCSVEnabledCheckBox.isSelected());
+        settings.setMaxLinesToRender(Integer.parseInt(pageLinesInput.getText()));
         settings.setDelimiter((Delimiter) delimiterComboBox.getSelectedItem());
         settings.setEscapeCharacter((EscapeCharacter) escapeCharacterComboBox.getSelectedItem());
         settings.setHighlightComments(highlightCommentsCheckBox.isSelected());
@@ -103,6 +115,7 @@ public class Settings implements EditorOptionsProvider {
         CsvSettings settings = CsvSettings.getInstance();
 
         rainbowCSVEnabledCheckBox.setSelected(settings.isEnabled());
+        pageLinesInput.setText(String.valueOf(settings.getMaxLinesToRender()));
         delimiterComboBox.setSelectedItem(settings.getDelimiter());
         escapeCharacterComboBox.setSelectedItem(settings.getEscapeCharacter());
         highlightCommentsCheckBox.setSelected(settings.isHighlightComments());

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin require-restart="true">
   <id>com.andrey4623.rainbowcsv</id>
   <name>Rainbow CSV</name>
-  <version>2.0.2</version>
+  <version>2.1.0</version>
   <vendor email="andreyka4623@gmail.com" url="https://github.com/andrey4623">Andrey Kolchanov</vendor>
 
   <description><![CDATA[
@@ -23,6 +23,7 @@
     ]]></description>
 
   <change-notes><![CDATA[
+    <p>2.1.0: added option to not render files above a certain, configurable, number of lines. Default is 1000 </p>
     <p>2.0.2: 2022.1 Intellij support.</p>
     <p>2.0.1: Small improvements.</p>
     <p>2.0: Supports custom column colors and a custom comment line prefix.</p>


### PR DESCRIPTION
Setting the value in settings will stop any file with more lines than configured from being rendered. This improves the performance on loading large files if they don't need to be highlighted. Default is 1000.